### PR TITLE
Fixes property 'children' is missing

### DIFF
--- a/src/ContextMenu.tsx
+++ b/src/ContextMenu.tsx
@@ -5,8 +5,8 @@ import { useEventListener, Portal, Menu, MenuButton, PortalProps, MenuButtonProp
 export interface ContextMenuProps<T extends HTMLElement> {
   renderMenu: () => JSX.Element | null;
   children: (ref: MutableRefObject<T | null>) => JSX.Element | null;
-  menuProps?: MenuProps;
-  portalProps?: PortalProps;
+  menuProps?: Omit<MenuProps, 'children'> & { children?: React.ReactNode };
+  portalProps?: Omit<PortalProps, 'children'> & { children?: React.ReactNode };
   menuButtonProps?: MenuButtonProps;
 }
 


### PR DESCRIPTION
### Problem:
When entering `menuProps` or `portalProps` on the ContextMenu component TypeScript points an error saying: 

> Property 'children' is missing in type '{ ... }' but required in type 'MenuProps'.

### Fix:
Changing the types to omit this property fixes this and prevents the user from creating an real error by assigning values to the children props, that should be assigned by React itself.

### Breaking changes:

- None